### PR TITLE
[PRO-1824] add mydevice route with other authentication from token

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,6 +30,7 @@ lazy val root = (project in file("."))
     val akkaV = "2.4.11"
     val scalaTestV = "3.0.0"
     val slickV = "3.1.1"
+    val sotaV = "0.2.9"
 
     Seq(
       "com.typesafe.akka" %% "akka-actor" % akkaV,
@@ -42,7 +43,8 @@ lazy val root = (project in file("."))
       "ch.qos.logback" % "logback-classic" % "1.1.3",
       "org.slf4j" % "slf4j-api" % "1.7.16",
 
-      "org.genivi" %% "sota-common" % "0.2.9",
+      "org.genivi" %% "sota-common" % sotaV,
+      "org.genivi" %% "sota-common-client" % sotaV,
 
       "com.typesafe.slick" %% "slick" % slickV,
       "com.typesafe.slick" %% "slick-hikaricp" % slickV,

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -38,6 +38,14 @@ core = {
   packagesApi = "/api/v1/packages"
 }
 
+device_registry = {
+  baseUri = "http://localhost:8083"
+  baseUri = ${?DEVICE_REGISTRY_API_URI}
+  devicesUri = "/api/v1/devices"
+  deviceGroupsUri = "/api/v1/device_groups"
+  mydeviceUri = "/api/v1/mydevice"
+}
+
 auth {
   protocol = "oauth.accesstoken"
   protocol = ${?AUTH_PROTOCOL}

--- a/src/main/scala/com/advancedtelematic/treehub/Boot.scala
+++ b/src/main/scala/com/advancedtelematic/treehub/Boot.scala
@@ -2,12 +2,14 @@ package com.advancedtelematic.treehub
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.server.{Directives, Route}
 import akka.stream.ActorMaterializer
 import com.advancedtelematic.treehub.http.{Http => TreeHubHttp}
 import com.advancedtelematic.treehub.http.{CoreClient, TreeHubRoutes}
 import com.typesafe.config.ConfigFactory
 import org.genivi.sota.db.BootMigrations
+import org.genivi.sota.client.DeviceRegistryClient
 import org.genivi.sota.http.LogDirectives.logResponseMetrics
 import org.genivi.sota.http.VersionDirectives.versionHeaders
 import org.slf4j.LoggerFactory
@@ -21,7 +23,13 @@ trait Settings {
   val port = config.getInt("server.port")
   val coreUri = config.getString("core.baseUri")
   val packagesApi = config.getString("core.packagesApi")
-  val treeHubUri = "https://" + config.getString("server.treeHubHost") + "/api/v1"
+  val treeHubUri = "https://" + config.getString("server.treeHubHost") + "/api/v1/mydevice"
+
+  val deviceRegistryUri = Uri(config.getString("device_registry.baseUri"))
+  val deviceRegistryApi = Uri(config.getString("device_registry.devicesUri"))
+  val deviceRegistryGroupApi = Uri(config.getString("device_registry.deviceGroupsUri"))
+  val deviceRegistryMyApi = Uri(config.getString("device_registry.mydeviceUri"))
+
 }
 
 object Boot extends App with Directives with Settings with VersionInfo with BootMigrations {
@@ -38,14 +46,19 @@ object Boot extends App with Directives with Settings with VersionInfo with Boot
 
   _log.info(s"Starting $version on http://$host:$port")
 
+  val deviceRegistry = new DeviceRegistryClient(
+    deviceRegistryUri, deviceRegistryApi, deviceRegistryGroupApi, deviceRegistryMyApi
+  )
+
   val tokenValidator = TreeHubHttp.tokenValidator
   val namespaceExtractor = (api: String) => TreeHubHttp.extractNamespace(api, allowEmpty = false)
+  val deviceNamespace = TreeHubHttp.deviceNamespace(deviceRegistry)
 
   val coreClient = new CoreClient(coreUri, packagesApi, treeHubUri)
 
   val routes: Route =
     (versionHeaders(version) & logResponseMetrics(projectName)) {
-      new TreeHubRoutes(tokenValidator, namespaceExtractor, coreClient).routes
+      new TreeHubRoutes(tokenValidator, namespaceExtractor, coreClient, deviceNamespace).routes
     }
 
   Http().bindAndHandle(routes, host, port)

--- a/src/main/scala/com/advancedtelematic/treehub/http/DeviceIdDirectives.scala
+++ b/src/main/scala/com/advancedtelematic/treehub/http/DeviceIdDirectives.scala
@@ -1,0 +1,51 @@
+package com.advancedtelematic.treehub.http
+
+import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import akka.http.scaladsl.server.{AuthorizationFailedRejection, Directive1, Directives, Rejection}
+import cats.data.Xor
+import com.advancedtelematic.jwt.JsonWebToken
+import eu.timepit.refined._
+import org.genivi.sota.data.Uuid
+import org.genivi.sota.http.NsFromToken
+
+object DeviceIdDirectives {
+  import Directives._
+
+  def fail[T](msg: String): Directive1[T] = extractLog.flatMap { l =>
+    l.info(s"Could not extract namespace: $msg")
+    reject(AuthorizationFailedRejection)
+  }
+
+  def removeSuffix(suffix: String): PartialFunction[String, String] ={
+    case x if x.endsWith(suffix) => x.dropRight(suffix.length)
+  }
+
+  def fromScope(token: JsonWebToken): Xor[String, Uuid] = {
+    val prefix = "ota-core."
+    val tokens = token.scope.underlying.collect {
+      case x if x.startsWith(prefix) => x.substring(prefix.length)
+    }.collect(removeSuffix(".read").orElse(removeSuffix(".write")))
+
+    if (tokens.size == 1) {
+      refineV[Uuid.Valid](tokens.toVector(0)) match {
+        case Left(msg) => Xor.Left(msg)
+        case Right(uuid) => Xor.Right(Uuid(uuid))
+      }
+    } else {
+      Xor.Left("Can't extract uuid from scopes")
+    }
+
+  }
+
+  def extractFromToken: Directive1[Uuid] = {
+    extractCredentials.flatMap {
+      case Some(OAuth2BearerToken(serializedToken)) =>
+        NsFromToken.parseToken[JsonWebToken](serializedToken).flatMap(fromScope _) match {
+          case Xor.Right(uuid) => provide(uuid)
+          case Xor.Left(msg) => fail(msg)
+        }
+      case _ => fail("No oauth token provided to extract namespace")
+    }
+  }
+
+}

--- a/src/main/scala/com/advancedtelematic/treehub/http/Http.scala
+++ b/src/main/scala/com/advancedtelematic/treehub/http/Http.scala
@@ -4,8 +4,11 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.server.directives.Credentials.{Missing, Provided}
 import akka.http.scaladsl.server.{Directives, _}
 import akka.stream.ActorMaterializer
+import org.genivi.sota.common.DeviceRegistry
 import org.genivi.sota.data.Namespace
 import org.genivi.sota.http.{NamespaceDirectives, TokenValidator}
+
+import scala.concurrent.ExecutionContext
 
 object Http {
   import Directives._
@@ -13,6 +16,13 @@ object Http {
   protected[http] val PASSWORD = "quochai1ech5oot5gaeJaifooqu6Saew"
 
   lazy val namespaceDirective = NamespaceDirectives.fromConfig()
+
+  def deviceNamespace(deviceRegistry: DeviceRegistry)
+                     (implicit ec: ExecutionContext): Directive1[Namespace] = {
+    DeviceIdDirectives.extractFromToken.flatMap { deviceId =>
+      onSuccess(deviceRegistry.fetchMyDevice(deviceId).map(_.namespace))
+    }
+  }
 
   def extractNamespace(apiVersion: String, allowEmpty: Boolean = false): Directive1[Namespace] = {
     apiVersion match {

--- a/src/main/scala/com/advancedtelematic/treehub/http/TreeHubRoutes.scala
+++ b/src/main/scala/com/advancedtelematic/treehub/http/TreeHubRoutes.scala
@@ -13,7 +13,8 @@ import slick.driver.MySQLDriver.api._
 
 class TreeHubRoutes(tokenValidator: String => Directive0,
                     namespaceExtractor : String => Directive1[Namespace],
-                    coreClient: Core)
+                    coreClient: Core,
+                    deviceNamespace: Directive1[Namespace])
                    (implicit val db: Database, ec: ExecutionContext, mat: Materializer) extends VersionInfo {
 
   import Directives._
@@ -22,14 +23,21 @@ class TreeHubRoutes(tokenValidator: String => Directive0,
 
   def versionExtractor: PathMatcher1[String] = matchVersion("v1") | matchVersion("v2")
 
+  def allRoutes(nsExtract: Directive1[Namespace]): Route = {
+    new ConfResource().route ~
+    new ObjectResource(nsExtract).route ~
+    new RefResource(nsExtract, coreClient).route
+  }
+
   val routes: Route =
     handleRejections(rejectionHandler) {
       ErrorHandler.handleErrors {
         pathPrefix("api" / versionExtractor) { apiVersion =>
           tokenValidator(apiVersion) {
-            new ConfResource().route ~
-            new ObjectResource(namespaceExtractor(apiVersion)).route ~
-            new RefResource(namespaceExtractor(apiVersion), coreClient).route
+            allRoutes(namespaceExtractor(apiVersion)) ~
+            pathPrefix("mydevice") {
+              allRoutes(deviceNamespace)
+            }
           }
         } ~ new HealthResource(db, versionMap).route
       }

--- a/src/test/scala/com/advancedtelematic/util/ResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/util/ResourceSpec.scala
@@ -44,7 +44,10 @@ trait ResourceSpec extends ScalatestRouteTest with DatabaseSpec {
   def namespaceExtractor(apiVersion: String) = Http.extractNamespace(apiVersion, allowEmpty = true)
   val testCore = new FakeCore()
 
-  lazy val routes = new TreeHubRoutes(_ => Directives.pass, namespaceExtractor, testCore).routes
+  lazy val routes = new TreeHubRoutes(_ => Directives.pass,
+                                      namespaceExtractor,
+                                      testCore,
+                                      Http.namespaceDirective).routes
 }
 
 


### PR DESCRIPTION
So devices don't have the namespace in the token, so the authentication code will not work (or rather the code to extract the namespace. So instead we are creating a special path for them, /mydevice acts like treehub but calculates the namespace differently.

The token for each device contains the following scope
```ota-core.{:uuid}.write ota-core.{:uuid}.read```
So we extract this uuid (make sure it is unique) and asks the device registry for the namespace, which means we need to be able to talk to the device registry.