### PR TITLE
[PRO-1824] package should use v2

### DIFF
--- a/src/main/scala/com/advancedtelematic/treehub/Boot.scala
+++ b/src/main/scala/com/advancedtelematic/treehub/Boot.scala
@@ -23,7 +23,7 @@ trait Settings {
   val port = config.getInt("server.port")
   val coreUri = config.getString("core.baseUri")
   val packagesApi = config.getString("core.packagesApi")
-  val treeHubUri = "https://" + config.getString("server.treeHubHost") + "/api/v1/mydevice"
+  val treeHubUri = "https://" + config.getString("server.treeHubHost") + "/api/v2/mydevice"
 
   val deviceRegistryUri = Uri(config.getString("device_registry.baseUri"))
   val deviceRegistryApi = Uri(config.getString("device_registry.devicesUri"))


### PR DESCRIPTION
Okay this is subtle, the /mydevice route doesn't care if it is v1 or v2
it does the same. So since it does the same I picked v1 (or rather I
didn't change it from v1 to v2). Now if you use v1 and asks for a file
that doesn't exists, akka will go through everything (fail authorization
in the old path) and fail to find the route in the mydevice. But because
of the failure of authorization in the old routes we get a 401 rather
than a 404.

ostree asks for an optional file called summary.sig it will be happy if
it gets a 404, but sad if it gets a 401. Hence we change it to be v2
which will succeed in the authorization (because we are not trying to
use the old way) but fail to match the route so it will give 404.