### PR TITLE
For each object uploaded, publish a new kafka message with current usage

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,16 +27,17 @@ lazy val root = (project in file("."))
   .settings(testOptions in UnitTest := Seq(Tests.Filter(unitFilter)))
   .settings(testOptions in IntegrationTest := Seq(Tests.Filter(itFilter)))
   .settings(Seq(libraryDependencies ++= {
-    val akkaV = "2.4.11"
+    val akkaV = "2.4.14"
+    val akkaHttpV = "10.0.0"
     val scalaTestV = "3.0.0"
     val slickV = "3.1.1"
-    val sotaV = "0.2.32"
+    val sotaV = "0.2.37"
 
     Seq(
       "com.typesafe.akka" %% "akka-actor" % akkaV,
       "com.typesafe.akka" %% "akka-stream" % akkaV,
-      "com.typesafe.akka" %% "akka-http-experimental" % akkaV,
-      "com.typesafe.akka" %% "akka-http-testkit" % akkaV,
+      "com.typesafe.akka" %% "akka-http" % akkaHttpV,
+      "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpV,
       "com.typesafe.akka" %% "akka-slf4j" % akkaV,
       "org.scalatest"     %% "scalatest" % scalaTestV % "test,it",
 
@@ -44,6 +45,7 @@ lazy val root = (project in file("."))
       "org.slf4j" % "slf4j-api" % "1.7.16",
 
       "org.genivi" %% "sota-common" % sotaV,
+      "org.genivi" %% "sota-common-messaging" % sotaV,
       "org.genivi" %% "sota-common-client" % sotaV,
 
       "com.typesafe.slick" %% "slick" % slickV,

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -73,3 +73,14 @@ authplus {
     secret = ${?AUTHPLUS_CLIENT_SECRET}
   }
 }
+
+messaging {
+  kafka {
+    groupIdPrefix = "auditor"
+    groupIdPrefix = ${?KAFKA_GROUP_ID}
+    topicSuffix = "dev"
+    topicSuffix = ${?KAFKA_TOPIC_SUFFIX}
+    host = "localhost:9092"
+    host = ${?KAFKA_HOST}
+  }
+}

--- a/src/main/scala/com/advancedtelematic/treehub/http/ObjectResource.scala
+++ b/src/main/scala/com/advancedtelematic/treehub/http/ObjectResource.scala
@@ -1,21 +1,29 @@
 package com.advancedtelematic.treehub.http
 
+import akka.actor.ActorRef
 import akka.http.scaladsl.model.{HttpEntity, MediaTypes, StatusCodes}
-import akka.http.scaladsl.server.{Directive1, PathMatcher1}
+import akka.http.scaladsl.server.{Directive0, Directive1, PathMatcher1}
 import akka.stream.Materializer
 import com.advancedtelematic.data.DataType.ObjectId
 import com.advancedtelematic.treehub.object_store.ObjectStore
+import com.advancedtelematic.treehub.repo_metrics.StorageUpdate.Update
 import org.genivi.sota.data.Namespace
 import slick.driver.MySQLDriver.api._
 
 import scala.concurrent.ExecutionContext
 
-class ObjectResource(namespace: Directive1[Namespace], objectStore: ObjectStore)
+class ObjectResource(namespace: Directive1[Namespace], objectStore: ObjectStore, storageHandler: ActorRef)
                     (implicit db: Database, ec: ExecutionContext, mat: Materializer) {
   import akka.http.scaladsl.server.Directives._
 
   val PrefixedObjectId: PathMatcher1[ObjectId] = (Segment / Segment).tmap { case (oprefix, osuffix) =>
     Tuple1(ObjectId(oprefix + osuffix))
+  }
+
+  private def hintNamespaceStorage(namespace: Namespace): Directive0 = mapResponse { resp =>
+    if(resp.status.isSuccess())
+      storageHandler ! Update(namespace)
+    resp
   }
 
   val route = namespace { ns =>
@@ -31,7 +39,7 @@ class ObjectResource(namespace: Directive1[Namespace], objectStore: ObjectStore)
         val f = objectStore.findBlob(ns, objectId).map(HttpEntity(MediaTypes.`application/octet-stream`, _))
         complete(f)
       } ~
-      post {
+      (post & hintNamespaceStorage(ns)) {
         fileUpload("file") { case (_, content) =>
           val f = objectStore.store(ns, objectId, content).map(_ => StatusCodes.OK)
           complete(f)

--- a/src/main/scala/com/advancedtelematic/treehub/http/TreeHubRoutes.scala
+++ b/src/main/scala/com/advancedtelematic/treehub/http/TreeHubRoutes.scala
@@ -1,5 +1,6 @@
 package com.advancedtelematic.treehub.http
 
+import akka.actor.ActorRef
 import akka.http.scaladsl.server.{Directives, _}
 import akka.stream.Materializer
 import org.genivi.sota.data.Namespace
@@ -17,14 +18,16 @@ class TreeHubRoutes(tokenValidator: Directive0,
                     namespaceExtractor: Directive1[Namespace],
                     coreClient: Core,
                     deviceNamespace: Directive1[Namespace],
-                    objectStore: ObjectStore)
+                    objectStore: ObjectStore,
+                    storageHandler: ActorRef
+                   )
                    (implicit val db: Database, ec: ExecutionContext, mat: Materializer) extends VersionInfo {
 
   import Directives._
 
   def allRoutes(nsExtract: Directive1[Namespace]): Route = {
     new ConfResource().route ~
-    new ObjectResource(nsExtract, objectStore).route ~
+    new ObjectResource(nsExtract, objectStore, storageHandler).route ~
     new RefResource(nsExtract, coreClient, objectStore).route
   }
 

--- a/src/main/scala/com/advancedtelematic/treehub/object_store/FilesystemUsage.scala
+++ b/src/main/scala/com/advancedtelematic/treehub/object_store/FilesystemUsage.scala
@@ -1,0 +1,25 @@
+package com.advancedtelematic.treehub.object_store
+
+import java.nio.file.attribute.BasicFileAttributes
+import java.nio.file.{FileVisitResult, Files, Path, SimpleFileVisitor}
+import java.util.concurrent.atomic.AtomicLong
+
+import scala.util.Try
+
+object FilesystemUsage {
+
+  def usage(path: Path): Try[Long] = {
+    val usage = new AtomicLong(0)
+
+    Try {
+      Files.walkFileTree(path, new SimpleFileVisitor[Path]() {
+        override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
+          usage.addAndGet(attrs.size())
+          FileVisitResult.CONTINUE
+        }
+      })
+
+      usage.get()
+    }
+  }
+}

--- a/src/main/scala/com/advancedtelematic/treehub/object_store/ObjectStore.scala
+++ b/src/main/scala/com/advancedtelematic/treehub/object_store/ObjectStore.scala
@@ -35,6 +35,8 @@ class ObjectStore(blobStore: BlobStore)(implicit ec: ExecutionContext, db: Datab
     blobStore.readFull(namespace, id)
   }
 
+  def usage(namespace: Namespace): Future[Long] = blobStore.usage(namespace)
+
   private def ensureExists(namespace: Namespace, id: ObjectId): Future[ObjectId] = {
     exists(namespace, id).flatMap {
       case true => Future.successful(id)

--- a/src/main/scala/com/advancedtelematic/treehub/repo_metrics/StorageUpdate.scala
+++ b/src/main/scala/com/advancedtelematic/treehub/repo_metrics/StorageUpdate.scala
@@ -1,0 +1,43 @@
+package com.advancedtelematic.treehub.repo_metrics
+
+import java.time.Instant
+
+import akka.actor.{Actor, ActorLogging, Props, Status}
+import com.advancedtelematic.treehub.object_store.ObjectStore
+import com.advancedtelematic.treehub.repo_metrics.StorageUpdate.{Done, Update}
+import org.genivi.sota.data.Namespace
+import org.genivi.sota.messaging.MessageBusPublisher
+import org.genivi.sota.messaging.Messages.ImageStorageUsage
+
+import scala.concurrent.Future
+
+object StorageUpdate {
+  case class Update(namespace: Namespace)
+  case class Done(namespace: Namespace)
+
+  def apply(messageBusPublisher: MessageBusPublisher, objectStore: ObjectStore): Props = {
+    Props(new StorageUpdate(messageBusPublisher, objectStore))
+  }
+}
+
+class StorageUpdate(publisher: MessageBusPublisher, objectStore: ObjectStore) extends Actor with ActorLogging {
+
+  import akka.pattern.pipe
+  import context.dispatcher
+
+  private def update(namespace: Namespace): Future[Done] = {
+    for {
+      usage <- objectStore.usage(namespace)
+      _ <- publisher.publish(ImageStorageUsage(namespace, Instant.now, usage))
+    } yield Done(namespace)
+  }
+
+  override def receive: Receive = {
+    case Update(ns) =>
+      update(ns).pipeTo(self)
+    case Done(ns) =>
+      log.info(s"published storage message for $ns")
+    case Status.Failure(ex) =>
+      log.error(ex, "Could not publish storage message")
+  }
+}

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -1,3 +1,5 @@
 database = {
   catalog = "ota_treehub_test"
 }
+
+messaging.mode = "test"

--- a/src/test/scala/com/advancedtelematic/treehub/object_store/FilesystemUsageSpec.scala
+++ b/src/test/scala/com/advancedtelematic/treehub/object_store/FilesystemUsageSpec.scala
@@ -1,0 +1,20 @@
+package com.advancedtelematic.treehub.object_store
+
+import java.nio.file.Files
+
+import com.advancedtelematic.util.TreeHubSpec
+
+import scala.collection.JavaConverters._
+
+
+class FilesystemUsageSpec extends TreeHubSpec {
+
+  test("can calculate a directory usage") {
+    val tempDir = Files.createTempDirectory("FilesystemUsageSpec")
+    val tempFile = Files.createTempFile(tempDir, "FilesystemUsageSpecFile", ".txt")
+
+    Files.write(tempFile, List("some text").asJava)
+
+    FilesystemUsage.usage(tempDir).get should be > 0l
+  }
+}

--- a/src/test/scala/com/advancedtelematic/treehub/repo_metrics/StorageUpdateSpec.scala
+++ b/src/test/scala/com/advancedtelematic/treehub/repo_metrics/StorageUpdateSpec.scala
@@ -1,0 +1,60 @@
+package com.advancedtelematic.treehub.repo_metrics
+
+import java.nio.file.{Files, Paths}
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.testkit.{TestActorRef, TestKitBase}
+import cats.data.Xor
+import com.advancedtelematic.treehub.object_store.{LocalFsBlobStore, ObjectStore}
+import com.advancedtelematic.treehub.repo_metrics.StorageUpdate.Update
+import com.advancedtelematic.util.{DatabaseSpec, TreeHubSpec}
+import org.genivi.sota.messaging.MessageBus
+import org.genivi.sota.messaging.Messages.ImageStorageUsage
+
+import scala.concurrent.duration._
+
+class StorageUpdateSpec extends TreeHubSpec with DatabaseSpec with TestKitBase  {
+  override implicit lazy val system: ActorSystem = ActorSystem("StorageUpdateSpec")
+
+  import system.dispatcher
+
+  implicit val mat = ActorMaterializer()
+
+  lazy val localFsDir = Files.createTempDirectory("StorageUpdateSpec")
+
+  lazy val namespaceDir = Files.createDirectories(Paths.get(s"${localFsDir.toAbsolutePath}/${defaultNs.get}"))
+
+  lazy val objectStore = new ObjectStore(new LocalFsBlobStore(localFsDir.toFile))
+
+  lazy val messageBus = MessageBus.publisher(system, config) match {
+    case Xor.Right(mbp) => mbp
+    case Xor.Left(err) => throw err
+  }
+
+  lazy val subject = TestActorRef(new StorageUpdate(messageBus, objectStore))
+
+  system.eventStream.subscribe(testActor, classOf[ImageStorageUsage])
+
+  test("sends update message to bus") {
+    val text = "some text, more text"
+
+    Files.write(Paths.get(namespaceDir.toString, "somefile.txt"), text.toCharArray.map(_.toByte))
+
+    subject ! Update(defaultNs)
+
+    expectMsgPF(10.seconds, "message with len == text.length") {
+      case p @ ImageStorageUsage(ns, _, len) if (ns == defaultNs) && (len == text.length) => p
+    }
+  }
+
+  test("recovers from errors") {
+    subject ! Update(defaultNs.copy(get = "notexistent"))
+
+    expectNoMsg(1.seconds)
+
+    subject ! Update(defaultNs)
+
+    expectMsgType[ImageStorageUsage](5.seconds)
+  }
+}

--- a/src/test/scala/com/advancedtelematic/util/ResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/util/ResourceSpec.scala
@@ -2,6 +2,7 @@ package com.advancedtelematic.util
 
 import java.nio.file.Files
 
+import akka.actor.{Actor, ActorLogging, Props}
 import akka.http.scaladsl.model.Multipart.FormData.BodyPart
 import akka.http.scaladsl.model.{HttpEntity, MediaTypes, Multipart}
 import akka.http.scaladsl.server.Directives
@@ -10,7 +11,10 @@ import com.advancedtelematic.common.DigestCalculator
 import com.advancedtelematic.data.DataType.Commit
 import com.advancedtelematic.treehub.http._
 import com.advancedtelematic.treehub.object_store.{LocalFsBlobStore, ObjectStore}
+import com.advancedtelematic.treehub.repo_metrics.StorageUpdate
+import com.advancedtelematic.util.FakeStorageUpdate.CurrentUsage
 import eu.timepit.refined.api.Refined
+import org.genivi.sota.data.Namespace
 import org.genivi.sota.http.NamespaceDirectives
 import org.scalatest.Suite
 
@@ -37,6 +41,23 @@ object ResourceSpec {
 
 }
 
+object FakeStorageUpdate {
+  case class CurrentUsage(ns: Namespace)
+}
+
+class FakeStorageUpdate extends Actor with ActorLogging {
+  var usages = Map.empty[Namespace, Long]
+
+  override def receive: Receive = {
+    case StorageUpdate.Update(ns) =>
+      usages += (ns -> (usages.getOrElse(ns, 0l) + 1l))
+      log.info(s"Would publish bus message for $ns")
+
+    case CurrentUsage(ns) =>
+      sender ! usages.getOrElse(ns, 0l)
+  }
+}
+
 trait ResourceSpec extends ScalatestRouteTest with DatabaseSpec {
   self: Suite =>
 
@@ -47,10 +68,12 @@ trait ResourceSpec extends ScalatestRouteTest with DatabaseSpec {
   lazy val namespaceExtractor = NamespaceDirectives.defaultNamespaceExtractor.map(_.namespace)
   val objectStore = new ObjectStore(new LocalFsBlobStore(Files.createTempDirectory("treehub").toFile))
 
+  val fakeStorageUpdate = system.actorOf(Props(new FakeStorageUpdate), "fake-storage-update")
+
   lazy val routes = new TreeHubRoutes(Directives.pass,
     namespaceExtractor,
     testCore,
-    namespaceExtractor, objectStore).routes
+    namespaceExtractor,
+    objectStore,
+    fakeStorageUpdate).routes
 }
-
-

--- a/src/test/scala/com/advancedtelematic/util/TreeHubSpec.scala
+++ b/src/test/scala/com/advancedtelematic/util/TreeHubSpec.scala
@@ -1,9 +1,11 @@
 package com.advancedtelematic.util
 
+import com.typesafe.config.ConfigFactory
 import org.genivi.sota.data.Namespace
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSuite, Matchers}
 
 abstract class TreeHubSpec extends FunSuite with Matchers with ScalaFutures {
   val defaultNs = Namespace("default")
+  val config = ConfigFactory.load()
 }


### PR DESCRIPTION
Usage is calculated in the background

This ticket needs changes to 3 projects:

https://github.com/advancedtelematic/treehub/pull/28
https://github.com/advancedtelematic/auditor/pull/5
https://github.com/advancedtelematic/rvi_sota_server/pull/708
