### PR TITLE
Use x-ats-namespace instead of auth.

### DIFF
--- a/src/main/scala/com/advancedtelematic/treehub/Boot.scala
+++ b/src/main/scala/com/advancedtelematic/treehub/Boot.scala
@@ -72,7 +72,6 @@ object Boot extends BootApp with Directives with Settings with VersionInfo
 
   val tokenValidator = TreeHubHttp.tokenValidator
   val namespaceExtractor = TreeHubHttp.extractNamespace.map(_.namespace)
-  val deviceNamespace = TreeHubHttp.deviceNamespace(deviceRegistry)
 
   val storage = {
     if(useS3)
@@ -93,7 +92,7 @@ object Boot extends BootApp with Directives with Settings with VersionInfo
 
   val routes: Route =
     (versionHeaders(version) & logResponseMetrics(projectName) & TreeHubHttp.transformAtsAuthHeader) {
-      new TreeHubRoutes(tokenValidator, namespaceExtractor, coreClient, deviceNamespace, objectStore, usageHandler).routes
+      new TreeHubRoutes(tokenValidator, namespaceExtractor, coreClient, objectStore, usageHandler).routes
     }
 
   Http().bindAndHandle(routes, host, port)

--- a/src/main/scala/com/advancedtelematic/treehub/http/TreeHubRoutes.scala
+++ b/src/main/scala/com/advancedtelematic/treehub/http/TreeHubRoutes.scala
@@ -17,7 +17,6 @@ import slick.driver.MySQLDriver.api._
 class TreeHubRoutes(tokenValidator: Directive0,
                     namespaceExtractor: Directive1[Namespace],
                     coreClient: Core,
-                    deviceNamespace: Directive1[Namespace],
                     objectStore: ObjectStore,
                     usageHandler: UsageMetricsRouter.HandlerRef
                    )
@@ -37,7 +36,7 @@ class TreeHubRoutes(tokenValidator: Directive0,
         (pathPrefix("api" / "v2") & tokenValidator) {
             allRoutes(namespaceExtractor) ~
             pathPrefix("mydevice") {
-              allRoutes(deviceNamespace)
+              allRoutes(namespaceExtractor)
             }
         } ~ new HealthResource(db, versionMap).route
       }

--- a/src/test/scala/com/advancedtelematic/util/ResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/util/ResourceSpec.scala
@@ -86,7 +86,6 @@ trait ResourceSpec extends ScalatestRouteTest with DatabaseSpec {
   lazy val routes = new TreeHubRoutes(Directives.pass,
     namespaceExtractor,
     testCore,
-    namespaceExtractor,
     objectStore,
     fakeUsageUpdate).routes
 }


### PR DESCRIPTION
This requires moving treehub into the internal network.

Do not merge.