### PR TITLE
[PRO-4083] limit size of refname

### DIFF
--- a/src/main/scala/com/advancedtelematic/data/DataType.scala
+++ b/src/main/scala/com/advancedtelematic/data/DataType.scala
@@ -18,7 +18,15 @@ object DataType {
 
   case class Ref(namespace: Namespace, name: RefName, value: Commit, objectId: ObjectId)
 
-  case class RefName(get: String) extends AnyVal
+  case class ValidRefName()
+
+  implicit val validRefName: Validate.Plain[String, ValidRefName] =
+    Validate.fromPredicate(refname => refname.length < 189,
+                           refname => s"$refname must be less than 189 characters",
+                           ValidRefName()
+    )
+
+  type RefName = Refined[String, ValidRefName]
 
   case class ValidObjectId()
 
@@ -98,12 +106,4 @@ object DataType {
     def from(bytes: Array[Byte]): Either[String, Commit] =
       refineV[ValidCommit](DigestCalculator.byteDigest()(bytes))
   }
-}
-
-object Codecs {
-  import io.circe.{Encoder, Decoder}
-  import DataType._
-
-  implicit val refNameEncoder: Encoder[RefName] = Encoder[String].contramap(_.get)
-  implicit val refNameDecoder: Decoder[RefName] = Decoder[String].map(RefName.apply)
 }

--- a/src/main/scala/com/advancedtelematic/treehub/client/CoreBusClient.scala
+++ b/src/main/scala/com/advancedtelematic/treehub/client/CoreBusClient.scala
@@ -15,7 +15,7 @@ class CoreBusClient(messageBusPublisher: MessageBusPublisher, treeHubUri: Uri) e
 
   private def mkTreehubCommit(ref: Ref, description: String): TreehubCommit = {
     //TODO: PRO-1802 pass the refname as the description until we can parse the real description out of the commit
-    val formattedRefName = ref.name.get.replaceFirst("^heads/", "").replace("/", "-")
+    val formattedRefName = ref.name.value.replaceFirst("^heads/", "").replace("/", "-")
     val size = 0 // TODO
     TreehubCommit(ref.namespace, ref.value, formattedRefName, description, size, treeHubUri.toString)
   }

--- a/src/main/scala/com/advancedtelematic/treehub/client/CoreHttpClient.scala
+++ b/src/main/scala/com/advancedtelematic/treehub/client/CoreHttpClient.scala
@@ -11,7 +11,6 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.unmarshalling.Unmarshaller
 import akka.http.scaladsl.util.FastFuture
 import akka.stream.ActorMaterializer
-import com.advancedtelematic.data.Codecs._
 import com.advancedtelematic.data.DataType.{Ref, RefName}
 import com.advancedtelematic.libats.auth.NamespaceDirectives.nsHeader
 import com.advancedtelematic.libats.codecs.AkkaCirce.refinedEncoder
@@ -41,8 +40,8 @@ class CoreHttpClient(baseUri: Uri, packagesUri: Uri, treeHubUri: Uri)
   def publishRef(ref: Ref, description: String)
                 (implicit ec: ExecutionContext): Future[Unit] = {
     val fileContents = ImageRequest(ref.value, ref.name, description, treeHubUri.toString).asJson.noSpaces
-    val bodyPart = BodyPart.Strict("file", HttpEntity(fileContents), Map("fileName" -> ref.name.get))
-    val formattedRefName = ref.name.get.replaceFirst("^heads/", "").replace("/", "-")
+    val bodyPart = BodyPart.Strict("file", HttpEntity(fileContents), Map("fileName" -> ref.name.value))
+    val formattedRefName = ref.name.value.replaceFirst("^heads/", "").replace("/", "-")
     val uri = baseUri.withPath(packagesUri.path + s"/treehub-$formattedRefName/${ref.value.value}")
                      .withQuery(Query("description" -> description))
     val req = HttpRequest(method = PUT, uri = uri, entity = Multipart.FormData(bodyPart).toEntity())

--- a/src/main/scala/com/advancedtelematic/treehub/db/RefRepository.scala
+++ b/src/main/scala/com/advancedtelematic/treehub/db/RefRepository.scala
@@ -18,8 +18,9 @@ object RefRepository {
 
 protected class RefRepository()(implicit db: Database, ec: ExecutionContext) {
   import RefRepository._
-  import com.advancedtelematic.libats.slick.db.SlickAnyVal._
   import com.advancedtelematic.data.DataType._
+  import com.advancedtelematic.libats.slick.codecs.SlickRefined._
+  import com.advancedtelematic.libats.slick.db.SlickAnyVal._
   import com.advancedtelematic.libats.slick.db.SlickExtensions._
 
   def persist(ref: Ref): Future[Unit] =

--- a/src/main/scala/com/advancedtelematic/treehub/http/RefResource.scala
+++ b/src/main/scala/com/advancedtelematic/treehub/http/RefResource.scala
@@ -2,8 +2,9 @@ package com.advancedtelematic.treehub.http
 
 import akka.http.scaladsl.server.{Directive, Directive1, Route}
 import akka.stream.Materializer
-import com.advancedtelematic.data.DataType.{Commit, Ref, RefName}
+import com.advancedtelematic.data.DataType.{Commit, Ref, ValidRefName}
 import com.advancedtelematic.libats.data.Namespace
+import com.advancedtelematic.libats.data.RefinedUtils._
 import com.advancedtelematic.libats.messaging_datatype.DataType.Commit
 import com.advancedtelematic.treehub.client.Core
 import com.advancedtelematic.treehub.db.RefRepository.RefNotFound
@@ -23,7 +24,7 @@ class RefResource(namespace: Directive1[Namespace], coreClient: Core, objectStor
 
   private val refUpdateProcess = new RefUpdateProcess(coreClient, objectStore)
 
-  private val RefNameUri = Segments.map(s => RefName(s.mkString("/")))
+  private val RefNameUri = Segments.flatMap(_.mkString("/").refineTry[ValidRefName].toOption)
 
   private val forcePushHeader: Directive[Tuple1[Boolean]] =
     optionalHeaderValueByName("x-ats-ostree-force").map(_.contains("true"))

--- a/src/test/scala/com/advancedtelematic/treehub/http/RefResourceIntegrationSpec.scala
+++ b/src/test/scala/com/advancedtelematic/treehub/http/RefResourceIntegrationSpec.scala
@@ -6,10 +6,11 @@ import cats.syntax.either._
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.stream.scaladsl.FileIO
-import com.advancedtelematic.data.DataType.{Commit, ObjectId, Ref, RefName, TObject}
+import com.advancedtelematic.data.DataType.{Commit, ObjectId, Ref, TObject}
 import com.advancedtelematic.libats.messaging_datatype.DataType.Commit
 import com.advancedtelematic.treehub.db.{ObjectRepositorySupport, RefRepositorySupport}
 import com.advancedtelematic.util.{ResourceSpec, TreeHubSpec}
+import eu.timepit.refined.api.Refined
 import io.circe.generic.auto._
 import org.scalatest.time.{Millis, Seconds, Span}
 import org.slf4j.LoggerFactory
@@ -41,7 +42,7 @@ class RefResourceIntegrationSpec extends TreeHubSpec with ResourceSpec with Obje
   test("accepts commit if object points to previous refName") {
     val newCommit = for {
       (commit, obj) <- createCommitObject("initial_commit.blob")
-      _ <- refRepository.persist(Ref(defaultNs, RefName("master"), commit, obj.id))
+      _ <- refRepository.persist(Ref(defaultNs, Refined.unsafeApply("master"), commit, obj.id))
       (newCommit, newObj) <- createCommitObject("second_commit.blob")
     } yield newCommit
 
@@ -62,7 +63,7 @@ class RefResourceIntegrationSpec extends TreeHubSpec with ResourceSpec with Obje
   test("rejects commit if object does not point to previous refName") {
     val commit = for {
       (commit, obj) <- createCommitObject("third_commit.blob")
-      _ <- refRepository.persist(Ref(defaultNs, RefName("not-master"), commit, obj.id))
+      _ <- refRepository.persist(Ref(defaultNs, Refined.unsafeApply("not-master"), commit, obj.id))
       (firstCommit, firstObj) <- createCommitObject("initial_commit.blob")
     } yield firstCommit
 
@@ -74,7 +75,7 @@ class RefResourceIntegrationSpec extends TreeHubSpec with ResourceSpec with Obje
   test("accepts invalid parent on force push") {
     val commit = for {
       (commit, obj) <- createCommitObject("third_commit.blob")
-      _ <- refRepository.persist(Ref(defaultNs, RefName("master-force"), commit, obj.id))
+      _ <- refRepository.persist(Ref(defaultNs, Refined.unsafeApply("master-force"), commit, obj.id))
       (firstCommit, firstObj) <- createCommitObject("initial_commit.blob")
     } yield firstCommit
 

--- a/src/test/scala/com/advancedtelematic/treehub/http/RefResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/treehub/http/RefResourceSpec.scala
@@ -66,4 +66,17 @@ class RefResourceSpec extends TreeHubSpec with ResourceSpec with RefRepositorySu
       status shouldBe StatusCodes.PreconditionFailed
     }
   }
+
+  test("refname is rejected if length is too long") {
+    val obj = new ClientTObject()
+    val ref = obj.commit
+
+    Post(apiUri(s"objects/${obj.prefixedObjectId}"), obj.form) ~> routes ~> check {
+      status shouldBe StatusCodes.OK
+    }
+
+    Post(apiUri("refs/" + "!"*189), ref) ~> routes ~> check {
+      status shouldBe StatusCodes.MethodNotAllowed
+    }
+  }
 }


### PR DESCRIPTION
A tuf target filepath most be smaller than 254 characters, and
the filepath is `$refname-$commit` which means that we limit refname
to be `254-1-64=189`.

In case we want to increase this number we need to:
* Add migration to reposerver db
* Add migration to director db
* Add migration to auditor db
* Update `TargetFilename` in libats