### PR TITLE
HEAD should return 404 if object size is -1

### DIFF
--- a/src/main/scala/com/advancedtelematic/treehub/http/ObjectResource.scala
+++ b/src/main/scala/com/advancedtelematic/treehub/http/ObjectResource.scala
@@ -37,7 +37,7 @@ class ObjectResource(namespace: Directive1[Namespace],
   val route = namespace { ns =>
     path("objects" / PrefixedObjectId) { objectId =>
       head {
-        val f = objectStore.isUploaded(ns, objectId).map {
+        val f = objectStore.exists(ns, objectId).map {
           case true => StatusCodes.OK
           case false => StatusCodes.NotFound
         }

--- a/src/main/scala/com/advancedtelematic/treehub/object_store/ObjectStore.scala
+++ b/src/main/scala/com/advancedtelematic/treehub/object_store/ObjectStore.scala
@@ -35,6 +35,12 @@ class ObjectStore(blobStore: BlobStore)(implicit ec: ExecutionContext, db: Datab
     createF.flatMap(_ => uploadF)
   }
 
+  def exists(namespace: Namespace, id: ObjectId): Future[Boolean] =
+    for {
+      dbExists <- objectRepository.exists(namespace, id)
+      fsExists <- blobStore.exists(namespace, id)
+    } yield fsExists && dbExists
+
   def isUploaded(namespace: Namespace, id: ObjectId): Future[Boolean] =
     for {
       dbUploaded <- objectRepository.isUploaded(namespace, id)

--- a/src/test/scala/com/advancedtelematic/treehub/http/ObjectResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/treehub/http/ObjectResourceSpec.scala
@@ -91,20 +91,6 @@ class ObjectResourceSpec extends TreeHubSpec with ResourceSpec with ObjectReposi
     }
   }
 
-  test("HEAD returns 404 if file size is invalid") {
-    val obj = new ClientTObject()
-
-    Post(apiUri(s"objects/${obj.prefixedObjectId}"), obj.form) ~> routes ~> check {
-      status shouldBe StatusCodes.OK
-    }
-
-    objectRepository.updateSize(defaultNs, obj.objectId, -1).futureValue
-
-    Head(apiUri(s"objects/${obj.prefixedObjectId}")) ~> routes ~> check {
-      status shouldBe StatusCodes.NotFound
-    }
-  }
-
   test("HEAD returns 200 if commit exists") {
     val obj = new ClientTObject()
 


### PR DESCRIPTION
This would defeat the point of using -1 to reserve the object for
upload, as clients would still try to push the object while another
client was uploading the same object