### PR TITLE
add migration to delete stale objects

### DIFF
--- a/src/main/resources/db/migration/V12__delete_stale_objects.sql
+++ b/src/main/resources/db/migration/V12__delete_stale_objects.sql
@@ -1,0 +1,5 @@
+create table _deleted_objects as
+select * from object where `size` = -1;
+
+delete from object where `size` = -1
+;


### PR DESCRIPTION
Users cannot re upload an object if size is -1, because HEAD always returns 2xx. This deletes the objects and allows users to upload them again.
