### PR TITLE
Publish latest tag when building image

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -75,7 +75,7 @@ dockerRepository := Some("advancedtelematic")
 
 packageName in Docker := packageName.value
 
-dockerUpdateLatest := false
+dockerUpdateLatest := true
 
 dockerAliases ++= Seq(dockerAlias.value.withTag(git.formattedShaVersion.value))
 


### PR DESCRIPTION
Some systems need to know what is the latest container version. For
example HAT deployments.

CI using gitlab no longer pushes `artifacts.txt` to S3 as teamcity
did. So we need to push this tag to `:latest` so that services can use
the `latest` tag.