### PR TITLE
Add index to object.status

### DIFF
--- a/src/main/resources/db/migration/V16__add_object_status_index.sql
+++ b/src/main/resources/db/migration/V16__add_object_status_index.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `object` ADD INDEX `object_status_idx` (`status`)
+;


### PR DESCRIPTION
During the last week we noticed the treehub db using more cpu than
usual, even though the app was not handling any requests.

upon investigation using show processlist, we noticed several queries
taking 4s or more:

select `namespace`, `object_id`, `size`, `status`, `created_at` from
`object` where `status` = 'CLIENT_UPLOADING'

This commit adds an index to speed up this query