### PR TITLE
Remove mentioning of license in README which trips off OSS scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,4 @@ To test the current implementation, the following steps can be followed:
 
         This is my file. There are many files like this, but this one is mine.
 
-## License
-
-This code is licensed under the [Mozilla Public License 2.0](LICENSE), a copy of which can be found in this repository. All code is copyright HERE Europe B.V., 2016-2020.
-
 [1]: https://github.com/advancedtelematic/ota-community-edition


### PR DESCRIPTION
Signed-off-by: Jochen Schneider <j.schneider@here.com>

Before: https://artifactory.in.here.com/artifactory/here-oss-local/job-results/9768/treehub-625c06a5a6c99907a8f125a303d58472d581b157-2020-02-24-scan-report.html

After: https://artifactory.in.here.com/artifactory/here-oss-local/job-results/9934/treehub-7975fcb9d528135ff2a7cf5a206009252185ff5b-2020-03-02-scan-report.html